### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.13.0-28-g3fbe925
+_commit: v0.13.0-29-g6bdca11
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: none
 conda_channel: conda-forge

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -26,6 +26,7 @@ keys = [
     "tool.pyright",
     "tool.ty",
     "tool.uv",
+    "tool.uv-locker.requirements",
 ]
 
 [rule.formatting]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,17 +401,6 @@ skip-package = true
 style = "requirements"
 
 [tool.uv-locker]
-<<<<<<< before updating
-requirements = [
-    { path = "requirements/uvx-tools.txt", python = "min", output-file = "requirements/lock/uvx-tools.txt", options = [
-        "--no-deps",
-        "--no-strip-extras",
-        "--universal",
-    ] },
-]
-=======
-pip-compile-config-file = "requirements/uv.toml"
->>>>>>> after updating
 scripts = [
     "tools/check_dist_version.py",
     "tools/clean_kernelspec.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,6 +401,7 @@ skip-package = true
 style = "requirements"
 
 [tool.uv-locker]
+<<<<<<< before updating
 requirements = [
     { path = "requirements/uvx-tools.txt", python = "min", output-file = "requirements/lock/uvx-tools.txt", options = [
         "--no-deps",
@@ -408,10 +409,23 @@ requirements = [
         "--universal",
     ] },
 ]
+=======
+pip-compile-config-file = "requirements/uv.toml"
+>>>>>>> after updating
 scripts = [
     "tools/check_dist_version.py",
     "tools/clean_kernelspec.py",
     "tools/sync_pyproject_min_versions.py",
+]
+
+[[tool.uv-locker.requirements]]
+path = "requirements/uvx-tools.txt"
+output-file = "requirements/lock/uvx-tools.txt"
+python = "min"
+options = [
+    "--no-deps",
+    "--no-strip-extras",
+    "--universal",
 ]
 
 # * Other tools ----------------------------------------------------------------


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. Resolve conflicts.

Files changed (`git status --short`):
 M .copier-answers.yml
 M .taplo.toml
UU pyproject.toml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.