### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.13.1-11-gd9d511e
+_commit: v0.13.1-19-g9681d41
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: none
 conda_channel: conda-forge

--- a/.github/actions/setup-cached-uv-and-python/action.yml
+++ b/.github/actions/setup-cached-uv-and-python/action.yml
@@ -37,6 +37,6 @@ runs:
         python-version-file: ${{ inputs.python-version-file }}
     - name: Setup cached uv
       id: setup-cached-uv
-      uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51 # v2.5.0
+      uses: hynek/setup-cached-uv@34e35d30f1ebc7421a5cc733bca38dcc62603960 # v2.6.0
       with:
         cache-dependency-path: ${{ inputs.cache-dependency-path }}


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .github/actions/setup-cached-uv-and-python/action.yml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.